### PR TITLE
Use clap crate for parsing argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,54 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +58,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bitflags"
@@ -25,6 +73,58 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "input-linux"
@@ -82,16 +182,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "2.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "theclicker"
 version = "0.1.3"
 dependencies = [
  "base64",
+ "clap",
  "input-linux",
  "input-linux-sys",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ keywords = ["autoclicker", "theclicker"]
 [dependencies]
 input-linux = "0.6.0"
 input-linux-sys = "0.8.0"
-base64 = "0.13.0"
+base64 = "0.21.4"
+clap = { version = "4.4.3", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,32 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    /// Cleaning the cache
+    #[arg(long, default_value_t = false)]
+    pub clear_cache: bool,
+
+    /// Set the cooldown in milliseconds
+    #[arg(short, long, default_value_t = 25)]
+    pub cooldown: u64,
+
+    /// Bind left autoclicker to keycode
+    #[arg(short, long, default_value_t = 275)]
+    pub left_bind: u16,
+
+    /// Bind right autoclicker to keycode
+    #[arg(short, long, default_value_t = 276)]
+    pub right_bind: u16,
+
+    /// For finding what key is pressed
+    #[arg(short, long, default_value_t = false)]
+    pub find_keycodes: bool,
+
+    /// For not beeping when the autoclicker state is changed
+    #[arg(short, long, default_value_t = false)]
+    pub no_beep: bool,
+
+    #[arg(long, default_value_t = false)]
+    pub debug: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod args;
 mod device;
 
 use std::{
@@ -35,6 +36,7 @@ pub struct State {
 
     beep: bool,
 }
+
 impl State {
     fn try_from_cache() -> Device {
         match File::open("/tmp/TheClicker") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,107 +1,36 @@
-use std::{fs, process::abort};
+pub mod args;
+pub mod device;
 
-use input_linux::Key;
+use std::fs;
+
+use clap::Parser;
 use theclicker::State;
 
+use crate::args::Args;
+
 fn main() {
-    let mut cooldown = 25;
-    let mut debug = false;
-    let mut find_keycodes = false;
-    let mut args: Vec<String> = Vec::new();
-    let mut left_bind: u16 = Key::ButtonSide.into();
-    let mut right_bind: u16 = Key::ButtonExtra.into();
+    let parse = Args::parse();
+
     let mut beep = true;
 
-    for arg in std::env::args() {
-        args.push(arg);
+    if parse.clear_cache {
+        let _ = fs::remove_file("/tmp/TheClicker");
     }
 
-    for (index, arg) in std::env::args().enumerate() {
-        if index > 0 {
-            match arg.as_str() {
-                "--clear-cache" => {
-                    let _ = fs::remove_file("/tmp/TheClicker");
-                }
-                "--cooldown" => {
-                    if let Some(arg) = args.get(index + 1) {
-                        let num = match arg.trim().parse::<u64>() {
-                            Ok(num) => num,
-                            Err(_) => {
-                                eprintln!("Specify a number!");
-                                abort()
-                            }
-                        };
-                        cooldown = num;
-                    } else {
-                        println!("After --cooldown specify the cooldown");
-                        abort()
-                    }
-                }
-                "--help" => {
-                    println!("--clear-cache for cleaning the cache!");
-                    println!("--cooldown [num] for set the cooldown in milliseconds!");
-                    println!("--left-bind [keycode] bind left autoclicker to keycode");
-                    println!("--right-bind [keycode] bind right autoclicker to keycode");
-                    println!("--find-keycodes for finding what key is press");
-                    println!("--no-beep for not beeping when the autoclicker state is changed");
-                    return;
-                }
-                "--debug" => {
-                    debug = true;
-                    println!("Debugging!");
-                }
-                "--left-bind" => {
-                    if let Some(arg) = args.get(index + 1) {
-                        let num = match arg.trim().parse::<u16>() {
-                            Ok(num) => num,
-                            Err(_) => {
-                                println!("Specify a keycode number!");
-                                return;
-                            }
-                        };
-                        left_bind = num;
-                        println!("Left autoclicker is bind on {}", num);
-                    } else {
-                        eprintln!("No keycode after --left-bind");
-                        abort()
-                    }
-                }
-                "--right-bind" => {
-                    if let Some(arg) = args.get(index + 1) {
-                        let num = match arg.trim().parse::<u16>() {
-                            Ok(num) => num,
-                            Err(_) => {
-                                println!("Specify a keycode number!");
-                                return;
-                            }
-                        };
-                        right_bind = num;
-                        println!("Right autoclicker is bind on {}", num);
-                    } else {
-                        eprintln!("No keycode after --right-bind");
-                        abort()
-                    }
-                }
-                "--find-keycodes" => {
-                    find_keycodes = true;
-                    println!("Autoclicker inactive!");
-                }
-                "--no-beep" => {
-                    beep = false;
-                    println!("Beep off");
-                }
-                _ => {
-                    println!("Invalid argument: {arg}");
-                    abort();
-                }
-            }
-        }
+    if parse.no_beep {
+        beep = false;
     }
 
-    let state = State::new(cooldown, debug, find_keycodes, left_bind, right_bind, beep);
+    let state = State::new(
+        parse.cooldown,
+        parse.debug,
+        parse.find_keycodes,
+        parse.left_bind,
+        parse.right_bind,
+        beep,
+    );
     println!("Launched!\n");
-
-    println!("Cooldown is set to {}ms!", cooldown);
+    println!("Cooldown is set to {}ms!", parse.cooldown);
 
     state.main_loop();
 }


### PR DESCRIPTION
Hi,

After having some difficulty with parameters like cooldown:

```sh
~> sudo ~/.cargo/bin/theclicker --cooldown 1500
Invalid argument: 1500
Abandon
```

I check and i found this implementation of parsing is not the best and i think using a crate for this is a good idea.  
I choose clap, for the simplicity (for me) to configure with derive.

Most of the variable initialized before parsing the argument are removed, `Args` struct doing this jobs now.